### PR TITLE
feat: expose modules as flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,16 +29,6 @@
         ];
 
         flake.lib = {
-          listModules =
-            path:
-            let
-              entries = builtins.readDir path;
-              isNixFileOrDir =
-                name: type: type == "directory" || (type == "regular" && nixpkgs.lib.strings.hasSuffix ".nix" name);
-              filteredNames = nixpkgs.lib.attrsets.filterAttrs isNixFileOrDir entries;
-            in
-            map (name: path + "/${name}") (builtins.attrNames filteredNames);
-
           # Helper to convert directory entries to module attrset
           mkModulesFromDir =
             path:

--- a/flake.nix
+++ b/flake.nix
@@ -60,26 +60,23 @@
         # home-manager modules
         flake.homeManagerModules =
           let
-            modulesDir = ./modules/home;
-            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+            modules = inputs.self.lib.mkModulesFromDir ./modules/home;
           in
-          modules // { default = modulesDir; };
+          modules // { default.imports = builtins.attrValues modules; };
 
         # nix-darwin modules
         flake.darwinModules =
           let
-            modulesDir = ./modules/nix-darwin;
-            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+            modules = inputs.self.lib.mkModulesFromDir ./modules/nix-darwin;
           in
-          modules // { default = modulesDir; };
+          modules // { default.imports = builtins.attrValues modules; };
 
         # NixOS modules
         flake.nixosModules =
           let
-            modulesDir = ./modules/nixos;
-            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+            modules = inputs.self.lib.mkModulesFromDir ./modules/nixos;
           in
-          modules // { default = modulesDir; };
+          modules // { default.imports = builtins.attrValues modules; };
 
         imports = [
           inputs.treefmt-nix.flakeModule

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,48 @@
               filteredNames = nixpkgs.lib.attrsets.filterAttrs isNixFileOrDir entries;
             in
             map (name: path + "/${name}") (builtins.attrNames filteredNames);
+
+          # Helper to convert directory entries to module attrset
+          mkModulesFromDir =
+            path:
+            let
+              entries = builtins.readDir path;
+              isNixFileOrDir =
+                name: type: type == "directory" || (type == "regular" && nixpkgs.lib.strings.hasSuffix ".nix" name);
+              filteredEntries = nixpkgs.lib.attrsets.filterAttrs isNixFileOrDir entries;
+              toModuleName = name: nixpkgs.lib.strings.removeSuffix ".nix" name;
+            in
+            builtins.listToAttrs (
+              map (name: {
+                name = toModuleName name;
+                value = path + "/${name}";
+              }) (builtins.attrNames filteredEntries)
+            );
         };
+
+        # home-manager modules
+        flake.homeManagerModules =
+          let
+            modulesDir = ./modules/home;
+            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+          in
+          modules // { default = modulesDir; };
+
+        # nix-darwin modules
+        flake.darwinModules =
+          let
+            modulesDir = ./modules/nix-darwin;
+            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+          in
+          modules // { default = modulesDir; };
+
+        # NixOS modules
+        flake.nixosModules =
+          let
+            modulesDir = ./modules/nixos;
+            modules = inputs.self.lib.mkModulesFromDir modulesDir;
+          in
+          modules // { default = modulesDir; };
 
         imports = [
           inputs.treefmt-nix.flakeModule

--- a/machines/hikuo-desktop/configuration.nix
+++ b/machines/hikuo-desktop/configuration.nix
@@ -7,13 +7,12 @@
   flake.nixosConfigurations.hikuo-desktop = withSystem "x86_64-linux" (
     { inputs', ... }:
     inputs.nixpkgs.lib.nixosSystem {
-      modules =
-        [
-          inputs.home-manager.nixosModules.home-manager
-          inputs.catppuccin.nixosModules.catppuccin
-          inputs.mylib.nixosModules.default
-        ]
-        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
+      modules = [
+        inputs.home-manager.nixosModules.home-manager
+        inputs.catppuccin.nixosModules.catppuccin
+        inputs.mylib.nixosModules.default
+      ]
+      ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-desktop/configuration.nix
+++ b/machines/hikuo-desktop/configuration.nix
@@ -7,12 +7,13 @@
   flake.nixosConfigurations.hikuo-desktop = withSystem "x86_64-linux" (
     { inputs', ... }:
     inputs.nixpkgs.lib.nixosSystem {
-      modules = [
-        inputs.home-manager.nixosModules.home-manager
-        inputs.catppuccin.nixosModules.catppuccin
-      ]
-      ++ inputs.mylib.lib.listModules ./modules
-      ++ inputs.mylib.lib.listModules ../../modules/nixos;
+      modules =
+        [
+          inputs.home-manager.nixosModules.home-manager
+          inputs.catppuccin.nixosModules.catppuccin
+          inputs.mylib.nixosModules.default
+        ]
+        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-desktop/modules/home/base.nix
+++ b/machines/hikuo-desktop/modules/home/base.nix
@@ -1,22 +1,23 @@
 {
+  inputs,
   userInfo,
   ...
 }:
 rec {
-  imports = [
-    ../../../../modules/home/my.nix
-    ../../../../modules/home/core
-    ../../../../modules/home/fonts
-    ../../../../modules/home/terminal
-    ../../../../modules/home/alacritty
-    ../../../../modules/home/zellij
-    ../../../../modules/home/git
-    ../../../../modules/home/editor
-    ../../../../modules/home/browser
-    ../../../../modules/home/cli-tools.nix
-    ../../../../modules/home/gui-tools
-    ../../../../modules/home/fileServer.nix
-    ../../../../modules/home/unixporn/aylur
+  imports = with inputs.mylib.homeManagerModules; [
+    my
+    core
+    fonts
+    terminal
+    alacritty
+    zellij
+    git
+    editor
+    browser
+    cli-tools
+    gui-tools
+    fileServer
+    unixporn
   ];
 
   # nixpkgs

--- a/machines/hikuo-homeserver/modules/home/default.nix
+++ b/machines/hikuo-homeserver/modules/home/default.nix
@@ -1,18 +1,19 @@
 {
+  inputs,
   userInfo,
   ...
 }:
 rec {
-  imports = [
-    ../../../../modules/home/my.nix
-    ../../../../modules/home/core
-    ../../../../modules/home/terminal
-    ../../../../modules/home/alacritty
-    ../../../../modules/home/zellij
-    ../../../../modules/home/git
-    ../../../../modules/home/editor
-    ../../../../modules/home/cli-tools.nix
-    ../../../../modules/home/fileServer.nix
+  imports = with inputs.mylib.homeManagerModules; [
+    my
+    core
+    terminal
+    alacritty
+    zellij
+    git
+    editor
+    cli-tools
+    fileServer
   ];
 
   catppuccin.enable = true;

--- a/machines/hikuo-laptop/configuration.nix
+++ b/machines/hikuo-laptop/configuration.nix
@@ -7,29 +7,30 @@
   flake.nixosConfigurations.hikuo-laptop = withSystem "x86_64-linux" (
     { inputs', ... }:
     inputs.nixpkgs.lib.nixosSystem {
-      modules = [
-        inputs.nixos-hardware.nixosModules.microsoft-surface-laptop-amd
-        inputs.home-manager.nixosModules.home-manager
-        {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-          home-manager.users.hikuo = import ./modules/home;
-          home-manager.backupFileExtension = "backup";
+      modules =
+        [
+          inputs.nixos-hardware.nixosModules.microsoft-surface-laptop-amd
+          inputs.home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.hikuo = import ./modules/home;
+            home-manager.backupFileExtension = "backup";
 
-          home-manager.extraSpecialArgs = {
-            inherit inputs inputs';
-            userInfo = {
-              username = "hikuo";
-              wallpaperPath = "/home/hikuo/Pictures/wallpaper.jpg";
-              git = {
-                username = "hikuohiku";
-                email = "hikuohiku@gmail.com";
+            home-manager.extraSpecialArgs = {
+              inherit inputs inputs';
+              userInfo = {
+                username = "hikuo";
+                wallpaperPath = "/home/hikuo/Pictures/wallpaper.jpg";
+                git = {
+                  username = "hikuohiku";
+                  email = "hikuohiku@gmail.com";
+                };
               };
             };
-          };
-        }
-      ]
-      ++ inputs.mylib.lib.listModules ./modules;
+          }
+        ]
+        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-laptop/configuration.nix
+++ b/machines/hikuo-laptop/configuration.nix
@@ -7,30 +7,29 @@
   flake.nixosConfigurations.hikuo-laptop = withSystem "x86_64-linux" (
     { inputs', ... }:
     inputs.nixpkgs.lib.nixosSystem {
-      modules =
-        [
-          inputs.nixos-hardware.nixosModules.microsoft-surface-laptop-amd
-          inputs.home-manager.nixosModules.home-manager
-          {
-            home-manager.useGlobalPkgs = true;
-            home-manager.useUserPackages = true;
-            home-manager.users.hikuo = import ./modules/home;
-            home-manager.backupFileExtension = "backup";
+      modules = [
+        inputs.nixos-hardware.nixosModules.microsoft-surface-laptop-amd
+        inputs.home-manager.nixosModules.home-manager
+        {
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.users.hikuo = import ./modules/home;
+          home-manager.backupFileExtension = "backup";
 
-            home-manager.extraSpecialArgs = {
-              inherit inputs inputs';
-              userInfo = {
-                username = "hikuo";
-                wallpaperPath = "/home/hikuo/Pictures/wallpaper.jpg";
-                git = {
-                  username = "hikuohiku";
-                  email = "hikuohiku@gmail.com";
-                };
+          home-manager.extraSpecialArgs = {
+            inherit inputs inputs';
+            userInfo = {
+              username = "hikuo";
+              wallpaperPath = "/home/hikuo/Pictures/wallpaper.jpg";
+              git = {
+                username = "hikuohiku";
+                email = "hikuohiku@gmail.com";
               };
             };
-          }
-        ]
-        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
+          };
+        }
+      ]
+      ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-laptop/modules/home/default.nix
+++ b/machines/hikuo-laptop/modules/home/default.nix
@@ -1,20 +1,21 @@
 {
+  inputs,
   userInfo,
   ...
 }:
 rec {
-  imports = [
-    ../../../../modules/home/my.nix
-    ../../../../modules/home/core
-    ../../../../modules/home/fonts
-    ../../../../modules/home/terminal
-    ../../../../modules/home/alacritty
-    ../../../../modules/home/zellij
-    ../../../../modules/home/git
-    ../../../../modules/home/editor
-    ../../../../modules/home/browser
-    ../../../../modules/home/cli-tools.nix
-    ../../../../modules/home/gui-tools
+  imports = with inputs.mylib.homeManagerModules; [
+    my
+    core
+    fonts
+    terminal
+    alacritty
+    zellij
+    git
+    editor
+    browser
+    cli-tools
+    gui-tools
   ];
 
   # home-manager

--- a/machines/hikuo-macbook/configuration.nix
+++ b/machines/hikuo-macbook/configuration.nix
@@ -7,12 +7,11 @@
   flake.darwinConfigurations.hikuo-macbook = withSystem "aarch64-darwin" (
     { inputs', ... }:
     inputs.nix-darwin.lib.darwinSystem {
-      modules =
-        [
-          inputs.home-manager.darwinModules.home-manager
-          inputs.mylib.darwinModules.default
-        ]
-        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
+      modules = [
+        inputs.home-manager.darwinModules.home-manager
+        inputs.mylib.darwinModules.default
+      ]
+      ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-macbook/configuration.nix
+++ b/machines/hikuo-macbook/configuration.nix
@@ -7,11 +7,12 @@
   flake.darwinConfigurations.hikuo-macbook = withSystem "aarch64-darwin" (
     { inputs', ... }:
     inputs.nix-darwin.lib.darwinSystem {
-      modules = [
-        inputs.home-manager.darwinModules.home-manager
-      ]
-      ++ inputs.mylib.lib.listModules ./modules
-      ++ inputs.mylib.lib.listModules ../../modules/nix-darwin;
+      modules =
+        [
+          inputs.home-manager.darwinModules.home-manager
+          inputs.mylib.darwinModules.default
+        ]
+        ++ builtins.attrValues (inputs.mylib.lib.mkModulesFromDir ./modules);
 
       specialArgs = {
         inherit inputs inputs';

--- a/machines/hikuo-macbook/flake.lock
+++ b/machines/hikuo-macbook/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765485905,
-        "narHash": "sha256-fk6zFzzcwz6su99K7UTxS2497+z/Cdk3FzNsacsmZKA=",
+        "lastModified": 1765990358,
+        "narHash": "sha256-l8x0gU8mnYaGMl+gWrsSHKBJlZWD8KXJfHTkRlFiPI0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "b49c675acd80931fc8b54290920a90189b461dcf",
+        "rev": "de1b60ca45a578f59f7d84c8d338b346017b2161",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765495779,
-        "narHash": "sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM=",
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "5635c32d666a59ec9a55cab87e898889869f7b71",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765606130,
-        "narHash": "sha256-KOP4QnkiRwiD5KEOr6ceF67rfTP1OqPmCCft6xDC3k4=",
+        "lastModified": 1766171975,
+        "narHash": "sha256-47Ee0bTidhF/3/sHuYnWRuxcCrrm0mBNDxBkOTd3wWQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d787ec69c3216ea33be1c0424fe65cb23aa8fb31",
+        "rev": "bb35f07cc95a73aacbaf1f7f46bb8a3f40f265b5",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1765474389,
-        "narHash": "sha256-CE79lVIw8sPMy/+ngSBUB5ua4FxkGrgDEeFTKcA5cqM=",
+        "lastModified": 1766231747,
+        "narHash": "sha256-NZGzVyRW13BlnjZQ2MD17a2JxcBscM9XoLkIUrQIkzY=",
         "owner": "hikuohiku",
         "repo": "dots-nix",
-        "rev": "7fe5e3ec3be258319492ac2d6cd6a4511425822a",
+        "rev": "4620759df0977d69705bab449bc0b975833e9338",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765065051,
-        "narHash": "sha256-b7W9WsvyMOkUScNxbzS45KEJp0iiqRPyJ1I3JBE+oEE=",
+        "lastModified": 1766038392,
+        "narHash": "sha256-ht/GuKaw5NT3M12xM+mkUtkSBVtzjJ8IHIy6R/ncv9g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "7e22bf538aa3e0937effcb1cee73d5f1bcc26f79",
+        "rev": "5fb45ece6129bd7ad8f7310df0ae9c00bae7c562",
         "type": "github"
       },
       "original": {
@@ -153,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765425892,
-        "narHash": "sha256-jlQpSkg2sK6IJVzTQBDyRxQZgKADC2HKMRfGCSgNMHo=",
+        "lastModified": 1766125104,
+        "narHash": "sha256-l/YGrEpLromL4viUo5GmFH3K5M1j0Mb9O+LiaeCPWEM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5d6bdbddb4695a62f0d00a3620b37a15275a5093",
+        "rev": "7d853e518814cca2a657b72eeba67ae20ebf7059",
         "type": "github"
       },
       "original": {
@@ -169,11 +169,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {

--- a/machines/hikuo-macbook/modules/home/default.nix
+++ b/machines/hikuo-macbook/modules/home/default.nix
@@ -5,8 +5,8 @@
   home-manager.users.hikuo = {
     imports = [
       ./home.nix
-    ]
-    ++ inputs.mylib.lib.listModules ../../../../modules/nix-darwin/home;
+      inputs.mylib.darwinModules.home
+    ];
   };
 
   home-manager.extraSpecialArgs = {


### PR DESCRIPTION
Add homeManagerModules, darwinModules, and nixosModules as flake outputs.
Each module category includes a default export and individual named modules
auto-generated from directory contents using a new mkModulesFromDir helper.