### PR TITLE
feat(coder): add reproducible workspace profile

### DIFF
--- a/machines/coder/flake.lock
+++ b/machines/coder/flake.lock
@@ -1,0 +1,155 @@
+{
+  "nodes": {
+    "fish-fzf-bd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737971088,
+        "narHash": "sha256-NAErU+F7CTf0wOfR1zfxw2TRBLPIHe5QDjEhyjCNLJE=",
+        "owner": "yuys13",
+        "repo": "fish-fzf-bd",
+        "rev": "fcbe9f6a75510365638dc6f790544c55ecb0ec3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yuys13",
+        "repo": "fish-fzf-bd",
+        "type": "github"
+      }
+    },
+    "fish-ghq": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1626409029,
+        "narHash": "sha256-6b1zmjtemNLNPx4qsXtm27AbtjwIZWkzJAo21/aVZzM=",
+        "owner": "decors",
+        "repo": "fish-ghq",
+        "rev": "cafaaabe63c124bf0714f89ec715cfe9ece87fa2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "decors",
+        "repo": "fish-ghq",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "herdr": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779907038,
+        "narHash": "sha256-bf1sVfGgfqpQYTRU2m0K/o2HEq5DV3R7nW5Lgll3+wI=",
+        "owner": "ogulcancelik",
+        "repo": "herdr",
+        "rev": "8180d76b30ca4281bdf2b43ff0316406f284413e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ogulcancelik",
+        "ref": "v0.6.4",
+        "repo": "herdr",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "my": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785747939,
+        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fish-fzf-bd": "fish-fzf-bd",
+        "fish-ghq": "fish-ghq",
+        "herdr": "herdr",
+        "home-manager": "home-manager",
+        "my": "my",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/machines/coder/flake.nix
+++ b/machines/coder/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Coder workspace Home Manager configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    fish-ghq = {
+      url = "github:decors/fish-ghq";
+      flake = false;
+    };
+    fish-fzf-bd = {
+      url = "github:yuys13/fish-fzf-bd";
+      flake = false;
+    };
+
+    herdr = {
+      url = "github:ogulcancelik/herdr/v0.6.4";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    my = {
+      url = "path:../..";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs@{
+      home-manager,
+      nixpkgs,
+      my,
+      ...
+    }:
+    let
+      pkgs = import nixpkgs {
+        system = "x86_64-linux";
+        config.allowUnfree = true;
+      };
+    in
+    {
+      homeConfigurations.coder = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        extraSpecialArgs = {
+          inherit inputs;
+          userInfo = {
+            username = "coder";
+          };
+        };
+        modules = [
+          my.homeManagerModules.default
+          ./modules/home.nix
+          ./modules/apps.nix
+        ];
+      };
+    };
+}

--- a/machines/coder/modules/apps.nix
+++ b/machines/coder/modules/apps.nix
@@ -1,0 +1,23 @@
+{
+  inputs,
+  pkgs,
+  ...
+}:
+{
+  mymodule.apps.claude.enable = true;
+  mymodule.apps.codex.enable = true;
+  mymodule.apps.cli-tools.base.enable = true;
+  mymodule.apps.cli-tools.development.enable = true;
+  mymodule.apps.cli-tools.infrastructure.enable = true;
+  mymodule.apps.core.enable = true;
+  mymodule.apps.eza.enable = true;
+  mymodule.apps.fish.enable = true;
+  mymodule.apps.fzf.enable = true;
+  mymodule.apps.git.enable = true;
+  mymodule.apps.lazygit.enable = true;
+  mymodule.apps.neovim.enable = true;
+
+  home.packages = [
+    inputs.herdr.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}

--- a/machines/coder/modules/home.nix
+++ b/machines/coder/modules/home.nix
@@ -1,0 +1,11 @@
+{
+  lib,
+  userInfo,
+  ...
+}:
+{
+  home.username = userInfo.username;
+  home.homeDirectory = lib.mkForce "/home/${userInfo.username}";
+  home.stateVersion = "26.11";
+  programs.home-manager.enable = true;
+}

--- a/modules/cli-tools/default.nix
+++ b/modules/cli-tools/default.nix
@@ -2,5 +2,12 @@
 {
   options.mymodule.apps.cli-tools = {
     enable = lib.mkEnableOption "CLI tool collection";
+    base.enable = lib.mkEnableOption "base CLI tools";
+    development.enable = lib.mkEnableOption "development CLI tools";
+    infrastructure.enable = lib.mkEnableOption "infrastructure CLI tools";
+    automation.enable = lib.mkEnableOption "automation CLI tools";
+    documents.enable = lib.mkEnableOption "document authoring CLI tools";
+    secrets.enable = lib.mkEnableOption "secrets CLI tools";
+    recording.enable = lib.mkEnableOption "terminal recording CLI tools";
   };
 }

--- a/modules/cli-tools/home.nix
+++ b/modules/cli-tools/home.nix
@@ -1,78 +1,96 @@
-{ config, lib, pkgs, ... }:
 {
-  config = lib.mkIf config.mymodule.apps.cli-tools.enable {
-    home.packages = with pkgs; [
-      # nix
-      nix-output-monitor
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.mymodule.apps.cli-tools;
+  enabled = category: cfg.enable || category.enable;
+in
+{
+  config = lib.mkMerge [
+    (lib.mkIf (enabled cfg.base) {
+      home.packages = with pkgs; [
+        nix-output-monitor
+        tree
+        fastfetch
+        gomi
+        rlwrap
+        gh
+        ripgrep
+        fd
+        sd
+        unar
+        unzip
+        p7zip
+        wget
+        httpie
+        yq-go
+        jwt-cli
+        jq
+        jnv
+        btop
+        ranger
+        lazydocker
+        dive
+        just
+      ];
 
-      devenv
+      home.sessionVariables.PAGER = "bat";
+    })
 
-      tree
-      fastfetch
-      gomi # trash
-      bitwarden-cli # いつからかビルドできなくなったので使いたくなる時までは一旦コメントアウトしておく
-      vhs # terminal screen capture
-      rlwrap # readline wrapper
-      gh
+    (lib.mkIf (enabled cfg.development) {
+      home.packages = with pkgs; [
+        devenv
+        tree-sitter
+        treefmt
+        nixfmt
+        yamlfmt
+      ];
 
-      # rust replacements
-      ripgrep # grep
-      fd # find
-      sd # sed
-
-      # archive
-      unar # unarchiver
-      unzip
-      p7zip # 7z
-
-      # http
-      wget
-      httpie
-
-      # analyze data format
-      yq-go
-      jwt-cli
-      jq
-      jnv
-
-      # tree-sitter
-      tree-sitter
-
-      ansible
-      ansible-lint
-
-      # ========== TUI TOOL ==========
-      btop # resource monitor
-      ranger # file manager
-      lazydocker
-      dive
-      just
-
-      terraform
-      kubernetes-helm
-      cachix
-      doppler
-      treefmt
-      nixfmt
-      yamlfmt
-      (texlive.withPackages (
-        ps: with ps; [
-          latexindent
-          chktex
-        ]
-      ))
-    ];
-
-    programs = {
-      direnv = {
-        enable = true;
-        nix-direnv.enable = true;
+      programs = {
+        direnv = {
+          enable = true;
+          nix-direnv.enable = true;
+        };
+        rbenv.enable = true;
       };
-      rbenv.enable = true;
-    };
+    })
 
-    home.sessionVariables = {
-      PAGER = "bat";
-    };
-  };
+    (lib.mkIf (enabled cfg.infrastructure) {
+      home.packages = with pkgs; [
+        terraform
+        kubernetes-helm
+        cachix
+        doppler
+      ];
+    })
+
+    (lib.mkIf (enabled cfg.automation) {
+      home.packages = with pkgs; [
+        ansible
+        ansible-lint
+      ];
+    })
+
+    (lib.mkIf (enabled cfg.documents) {
+      home.packages = [
+        (pkgs.texlive.withPackages (
+          ps: with ps; [
+            latexindent
+            chktex
+          ]
+        ))
+      ];
+    })
+
+    (lib.mkIf (enabled cfg.secrets) {
+      home.packages = [ pkgs.bitwarden-cli ];
+    })
+
+    (lib.mkIf (enabled cfg.recording) {
+      home.packages = [ pkgs.vhs ];
+    })
+  ];
 }


### PR DESCRIPTION
## Summary
- split CLI tools into opt-in categories while preserving `cli-tools.enable` compatibility
- add a Linux Home Manager profile for the persistent Coder workspace
- pin Herdr v0.6.4 and enable the base, development, and infrastructure tool sets

## Verification
- `nixfmt --check`
- Coder Home Manager evaluation
- `nix build --dry-run`
- existing macOS configuration evaluation with the local module override